### PR TITLE
chore: remove unused maven-enforcer-plugin from pom.xml to streamline…

### DIFF
--- a/transfer/pom.xml
+++ b/transfer/pom.xml
@@ -140,10 +140,6 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
           <!-- Uncomment to enable incremental compilation -->


### PR DESCRIPTION
remove unused maven-enforcer-plugin from pom.xml 